### PR TITLE
Add advanced traps, fog effects, and enemy behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             <span id="status-attack" class="status">攻撃: <span class="value">-</span></span>
             <span id="status-invincible" class="status">無敵: <span class="value">-</span></span>
             <span id="status-trap" class="status">罠効果: <span class="value">-</span></span>
+            <span id="status-field" class="status">環境: <span class="value">-</span></span>
           </div>
           <button id="pause-button">⏸ ポーズ</button>
         </div>


### PR DESCRIPTION
## Summary
- add HUD support for environmental status alongside existing attack/defense indicators
- implement new trap system with fog-of-war and noise lures, plus improved fog visibility handling and audio/visual feedback
- extend enemy AI with differentiated behaviours, A* pathfinding for strategists, and responsiveness to noise traps while updating rendering to respect fog visibility

## Testing
- not run (web-only project)


------
https://chatgpt.com/codex/tasks/task_e_68cd0cb92ec083229555df9fd7c46843