### PR TITLE
Implement fully featured maze action game

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,21 +18,7 @@
     </header>
 
     <main>
-      <section id="title-screen" class="screen active" aria-live="polite">
-        <div class="panel">
-          <h2>タイトル</h2>
-          <p>プレイヤー <span class="symbol">私</span> を操作して、<span class="symbol enemy">敵</span> を避けながらゴールを目指そう。</p>
-          <button id="start-button" class="primary">▶ はじめる</button>
-          <button id="show-howto">❔ 操作説明</button>
-          <div id="howto" class="hidden">
-            <p>PC: 矢印キー / WASD</p>
-            <p>スマホ: 画面下のDパッド、またはスワイプ</p>
-            <p>一時停止: Pキー / ⏸ボタン</p>
-          </div>
-        </div>
-      </section>
-
-      <section id="game-screen" class="screen" aria-live="polite">
+      <section id="game-screen" aria-live="polite">
         <div class="hud">
           <div>レベル: <span id="hud-level">1</span></div>
           <div>スコア: <span id="hud-score">0</span></div>
@@ -46,6 +32,8 @@
         </div>
         <div class="canvas-wrapper">
           <canvas id="game-canvas" width="480" height="640" aria-label="迷路ゲーム"></canvas>
+          <div id="loading-indicator" class="canvas-overlay">生成中…</div>
+          <div id="pause-overlay" class="canvas-overlay hidden">ポーズ中</div>
         </div>
         <div id="virtual-pad" aria-hidden="true">
           <div class="pad-row">
@@ -59,7 +47,22 @@
         </div>
       </section>
 
-      <section id="result-screen" class="screen" aria-live="polite">
+      <section id="title-screen" class="overlay-panel" aria-live="polite">
+        <div class="panel">
+          <h2>タイトル</h2>
+          <p>プレイヤー <span class="symbol">私</span> を操作して、<span class="symbol enemy">敵</span> を避けながらゴールを目指そう。</p>
+          <button id="start-button" class="primary">▶ はじめる</button>
+          <button id="show-howto">❔ 操作説明</button>
+          <div id="howto" class="hidden">
+            <p>PC: 矢印キー / WASD</p>
+            <p>スマホ: 画面下のDパッド、またはスワイプ</p>
+            <p>一時停止: Pキー / ⏸ボタン</p>
+            <p>デバッグ: G=グリッド V=フォグ L=次レベル</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="result-screen" class="overlay-panel hidden" aria-live="polite">
         <div class="panel">
           <h2>リザルト</h2>
           <p>スコア: <span id="result-score">0</span></p>

--- a/style.css
+++ b/style.css
@@ -51,16 +51,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-
-.screen {
-  display: none;
-  flex: 1;
   position: relative;
-}
-
-.screen.active {
-  display: flex;
 }
 
 .panel {
@@ -141,12 +132,21 @@ button:focus {
   padding: 4px 8px;
 }
 
+
+#game-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .canvas-wrapper {
   flex: 1;
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 8px;
+  position: relative;
 }
 
 #game-canvas {
@@ -155,6 +155,26 @@ button:focus {
   background: #050a10;
   border-radius: 16px;
   border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.canvas-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: bold;
+  color: #f5f5f5;
+  background: rgba(5, 10, 16, 0.65);
+  border-radius: 16px;
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+}
+
+#pause-overlay {
+  background: rgba(10, 15, 22, 0.5);
+  font-size: 1.6rem;
 }
 
 #virtual-pad {
@@ -190,6 +210,26 @@ button:focus {
   background: rgba(0, 0, 0, 0.5);
   z-index: 10;
   padding: 16px;
+}
+
+.overlay-panel {
+  position: absolute;
+  inset: 72px 0 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.overlay-panel.hidden {
+  display: none;
+}
+
+.overlay-panel .panel {
+  max-width: 100%;
+  pointer-events: auto;
 }
 
 ol {


### PR DESCRIPTION
## Summary
- keep the playfield visible at all times while layering title, result, pause, and ranking interfaces with mobile-friendly controls
- refresh the styles to support canvas overlays, responsive D-pad sizing, and dialog panels for settings and rankings
- implement configuration-driven maze generation, enemy AI, traps, items, fog handling, local ranking storage, and debug tools to scale difficulty across levels

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd190497d08322bb58cd8753e8022b