### PR TITLE
Implement mobile overlay controls and maze rework

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <div id="app">
-    <header class="top-bar">
+    <canvas id="game-canvas" width="480" height="640" aria-label="迷路ゲーム"></canvas>
+    <div id="touch-layer" aria-hidden="true"></div>
+
+    <header class="top-bar overlay-block">
       <h1 class="game-title">迷路アクション 私と敵</h1>
       <div class="top-controls">
         <button id="toggle-sound" aria-pressed="false">🔊 音ON</button>
@@ -17,90 +20,105 @@
       </div>
     </header>
 
-    <main>
-      <section id="game-screen" aria-live="polite">
-        <div class="hud">
-          <div>レベル: <span id="hud-level">1</span></div>
-          <div>スコア: <span id="hud-score">0</span></div>
-          <div class="status-strip">
-            <span id="status-attack" class="status">攻撃: <span class="value">-</span></span>
-            <span id="status-invincible" class="status">無敵: <span class="value">-</span></span>
-            <span id="status-trap" class="status">罠効果: <span class="value">-</span></span>
-            <span id="status-field" class="status">環境: <span class="value">-</span></span>
-          </div>
-          <button id="pause-button">⏸ ポーズ</button>
+    <section id="game-screen" class="overlay-block" aria-live="polite">
+      <div class="hud">
+        <div>レベル: <span id="hud-level">1</span></div>
+        <div>スコア: <span id="hud-score">0</span></div>
+        <div class="status-strip">
+          <span id="status-attack" class="status">攻撃: <span class="value">-</span></span>
+          <span id="status-invincible" class="status">無敵: <span class="value">-</span></span>
+          <span id="status-trap" class="status">罠効果: <span class="value">-</span></span>
+          <span id="status-field" class="status">環境: <span class="value">-</span></span>
+          <span id="status-dash" class="status">ダッシュ: <span class="value">Ready</span></span>
+          <span id="status-smoke" class="status">スモーク: <span class="value">0</span></span>
         </div>
-        <div class="canvas-wrapper">
-          <canvas id="game-canvas" width="480" height="640" aria-label="迷路ゲーム"></canvas>
-          <div id="loading-indicator" class="canvas-overlay">生成中…</div>
-          <div id="pause-overlay" class="canvas-overlay hidden">ポーズ中</div>
-        </div>
-        <div id="virtual-pad" aria-hidden="true">
-          <div class="pad-row">
-            <button data-dir="up" class="pad-btn" aria-label="上">▲</button>
-          </div>
-          <div class="pad-row">
-            <button data-dir="left" class="pad-btn" aria-label="左">◀</button>
-            <button data-dir="down" class="pad-btn" aria-label="下">▼</button>
-            <button data-dir="right" class="pad-btn" aria-label="右">▶</button>
-          </div>
-        </div>
-      </section>
+        <button id="pause-button">⏸ ポーズ</button>
+      </div>
+      <div id="loading-indicator" class="canvas-overlay">生成中…</div>
+      <div id="pause-overlay" class="canvas-overlay hidden">ポーズ中</div>
+    </section>
 
-      <section id="title-screen" class="overlay-panel" aria-live="polite">
-        <div class="panel">
-          <h2>タイトル</h2>
-          <p>プレイヤー <span class="symbol">私</span> を操作して、<span class="symbol enemy">敵</span> を避けながらゴールを目指そう。</p>
-          <button id="start-button" class="primary">▶ はじめる</button>
-          <button id="show-howto">❔ 操作説明</button>
-          <div id="howto" class="hidden">
-            <p>PC: 矢印キー / WASD</p>
-            <p>スマホ: 画面下のDパッド、またはスワイプ</p>
-            <p>一時停止: Pキー / ⏸ボタン</p>
-            <p>デバッグ: G=グリッド V=フォグ L=次レベル</p>
-          </div>
-        </div>
-      </section>
+    <div id="ability-buttons" class="overlay-block">
+      <button id="dash-button" class="ability-btn" aria-label="ダッシュ">⚡ ダッシュ</button>
+      <button id="smoke-button" class="ability-btn" aria-label="スモーク">💨 スモーク</button>
+    </div>
 
-      <section id="result-screen" class="overlay-panel hidden" aria-live="polite">
-        <div class="panel">
-          <h2>リザルト</h2>
-          <p>スコア: <span id="result-score">0</span></p>
-          <p>到達レベル: <span id="result-level">1</span></p>
-          <p>クリアタイム: <span id="result-time">0.0</span>s</p>
-          <form id="result-form">
-            <label>イニシャル (3文字)
-              <input id="initial-input" maxlength="3" pattern="[A-Za-zぁ-んァ-ヶ一-龥0-9]{1,3}" required />
-            </label>
-            <button type="submit" class="primary">保存</button>
-          </form>
-          <button id="retry-button">▶ もう一度</button>
-          <button id="back-title">◀ タイトルへ</button>
-        </div>
-      </section>
+    <div id="virtual-pad" class="floating-pad" data-state="full" aria-hidden="false">
+      <div class="pad-row">
+        <button data-dir="up" class="pad-btn" aria-label="上">▲</button>
+      </div>
+      <div class="pad-row">
+        <button data-dir="left" class="pad-btn" aria-label="左">◀</button>
+        <button data-dir="down" class="pad-btn" aria-label="下">▼</button>
+        <button data-dir="right" class="pad-btn" aria-label="右">▶</button>
+      </div>
+    </div>
 
-      <section id="ranking-panel" class="dialog hidden" role="dialog" aria-modal="true">
-        <div class="panel">
-          <h2>ランキング</h2>
-          <ol id="ranking-list"></ol>
-          <button id="reset-ranking">初期化</button>
-          <button id="close-ranking" class="secondary">閉じる</button>
-        </div>
-      </section>
+    <button id="pad-toggle" class="pad-toggle" aria-label="Dパッド切替" data-state="full">🕹</button>
 
-      <section id="settings-panel" class="dialog hidden" role="dialog" aria-modal="true">
-        <div class="panel">
-          <h2>設定</h2>
-          <label>視界半径: <input id="sight-range" type="range" min="3" max="10" value="5" /></label>
-          <label>Dパッドサイズ: <input id="pad-size" type="range" min="80" max="200" value="140" /></label>
-          <label>スワイプ感度: <input id="swipe-sensitivity" type="range" min="10" max="80" value="30" /></label>
-          <label>震動: <input id="vibration-toggle" type="checkbox" checked /></label>
-          <label>画面揺れ: <input id="screenshake-toggle" type="checkbox" checked /></label>
-          <label>フォグ表示: <input id="fog-toggle" type="checkbox" checked /></label>
-          <button id="close-settings" class="secondary">閉じる</button>
+    <div id="title-screen" class="overlay-panel" aria-live="polite">
+      <div class="panel">
+        <h2>タイトル</h2>
+        <p>プレイヤー <span class="symbol">私</span> を操作して、<span class="symbol enemy">敵</span> を避けながらゴールを目指そう。</p>
+        <button id="start-button" class="primary">▶ はじめる</button>
+        <button id="show-howto">❔ 操作説明</button>
+        <div id="howto" class="hidden">
+          <p>PC: 矢印キー / WASD</p>
+          <p>スマホ: 画面下のDパッド、またはスワイプ</p>
+          <p>ダッシュ: ⚡ボタン / Space</p>
+          <p>スモーク: 💨ボタン / Eキー</p>
+          <p>一時停止: Pキー / ⏸ボタン</p>
+          <p>デバッグ: G=グリッド V=フォグ L=次レベル</p>
         </div>
-      </section>
-    </main>
+      </div>
+    </div>
+
+    <section id="result-screen" class="overlay-panel hidden" aria-live="polite">
+      <div class="panel">
+        <h2>リザルト</h2>
+        <p>スコア: <span id="result-score">0</span></p>
+        <p>到達レベル: <span id="result-level">1</span></p>
+        <p>クリアタイム: <span id="result-time">0.0</span>s</p>
+        <form id="result-form">
+          <label>イニシャル (3文字)
+            <input id="initial-input" maxlength="3" pattern="[A-Za-zぁ-んァ-ヶ一-龥0-9]{1,3}" required />
+          </label>
+          <button type="submit" class="primary">保存</button>
+        </form>
+        <button id="retry-button">▶ もう一度</button>
+        <button id="back-title">◀ タイトルへ</button>
+      </div>
+    </section>
+
+    <section id="ranking-panel" class="dialog hidden" role="dialog" aria-modal="true">
+      <div class="panel">
+        <h2>ランキング</h2>
+        <ol id="ranking-list"></ol>
+        <button id="reset-ranking">初期化</button>
+        <button id="close-ranking" class="secondary">閉じる</button>
+      </div>
+    </section>
+
+    <section id="settings-panel" class="dialog hidden" role="dialog" aria-modal="true">
+      <div class="panel">
+        <h2>設定</h2>
+        <label>視界半径: <input id="sight-range" type="range" min="3" max="10" value="5" /></label>
+        <label>Dパッドサイズ: <input id="pad-size" type="range" min="80" max="200" value="140" /></label>
+        <label>スワイプ感度: <input id="swipe-sensitivity" type="range" min="10" max="80" value="30" /></label>
+        <label>震動: <input id="vibration-toggle" type="checkbox" checked /></label>
+        <label>画面揺れ: <input id="screenshake-toggle" type="checkbox" checked /></label>
+        <label>フォグ表示: <input id="fog-toggle" type="checkbox" checked /></label>
+        <button id="close-settings" class="secondary">閉じる</button>
+      </div>
+    </section>
+
+    <div id="tutorial-pop" class="tutorial hidden" role="status">
+      <div class="tutorial-body">
+        <h3>チュートリアル</h3>
+        <p>Dパッドは画面に重ねて表示されています。右下の🕹ボタンから縮小・非表示を切り替えできます。</p>
+        <button id="tutorial-close" class="primary">了解！</button>
+      </div>
+    </div>
   </div>
   <script src="main.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -2,72 +2,82 @@
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   width: 100%;
   height: 100%;
   font-family: "M PLUS 1p", "Noto Sans JP", sans-serif;
-  background: #101820;
+  background: #0b141d;
   color: #f5f5f5;
 }
 
 body {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
+  overflow: hidden;
+}
+
+.hidden {
+  display: none !important;
 }
 
 #app {
-  width: 100%;
-  max-width: 640px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  background: #050a10;
+}
+
+#game-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: block;
+  background: #050a10;
+  pointer-events: none;
+}
+
+#touch-layer {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  touch-action: none;
+  pointer-events: auto;
+  background: transparent;
+  z-index: 2;
+}
+
+.overlay-block {
+  position: fixed;
+  z-index: 5;
+  pointer-events: auto;
 }
 
 .top-bar {
+  top: calc(env(safe-area-inset-top, 12px));
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(92vw, 620px);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
-  background: #16212c;
-  border-radius: 12px;
-  padding: 8px 12px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: rgba(22, 33, 44, 0.85);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
 }
 
 .game-title {
-  font-size: 1.4rem;
+  font-size: clamp(1.1rem, 2.2vw, 1.6rem);
   margin: 0;
-}
-
-.top-controls button {
-  margin-left: 4px;
-}
-
-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  position: relative;
-}
-
-.panel {
-  background: rgba(20, 32, 44, 0.9);
-  border-radius: 16px;
-  padding: 16px;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
 }
 
 button {
   font-size: 1rem;
-  padding: 12px 16px;
+  padding: 10px 16px;
   border-radius: 12px;
   border: none;
   background: #284e8e;
@@ -78,6 +88,11 @@ button {
 
 button:active {
   transform: scale(0.97);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 button.secondary {
@@ -93,72 +108,40 @@ button:focus {
   outline-offset: 2px;
 }
 
-.hidden {
-  display: none !important;
-}
-
-.symbol {
-  font-weight: bold;
-  padding: 0 4px;
-  border-radius: 4px;
-  background: #2f6fed;
-}
-
-.symbol.enemy {
-  background: #d0006f;
+#game-screen {
+  top: calc(env(safe-area-inset-top, 12px) + 76px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(92vw, 620px);
 }
 
 .hud {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 8px;
-  padding: 8px;
-  background: rgba(15, 24, 34, 0.8);
-  border-radius: 12px;
-  font-size: 1rem;
+  padding: 10px 14px;
+  border-radius: 16px;
+  background: rgba(15, 24, 34, 0.82);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.32);
 }
 
 .status-strip {
   display: flex;
-  gap: 8px;
-  font-size: 0.9rem;
   flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.85rem;
 }
 
 .status {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
   padding: 4px 8px;
-}
-
-
-#game-screen {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.canvas-wrapper {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 8px;
-  position: relative;
-}
-
-#game-canvas {
-  width: 100%;
-  height: 100%;
-  background: #050a10;
-  border-radius: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .canvas-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
   display: flex;
   align-items: center;
@@ -167,90 +150,193 @@ button:focus {
   font-weight: bold;
   color: #f5f5f5;
   background: rgba(5, 10, 16, 0.65);
-  border-radius: 16px;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(3px);
+  z-index: 6;
 }
 
 #pause-overlay {
-  background: rgba(10, 15, 22, 0.5);
   font-size: 1.6rem;
 }
 
-#virtual-pad {
+.floating-pad {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 16px) + 110px);
+  left: 50%;
+  transform: translateX(-50%);
   display: grid;
-  gap: 4px;
+  gap: 6px;
   justify-items: center;
-  margin-top: 8px;
+  padding: 16px 20px;
+  border-radius: 28px;
+  background: rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+  z-index: 10;
+  transition: transform 0.2s ease, opacity 0.2s;
 }
 
-#virtual-pad[aria-hidden="true"] {
-  display: none;
+.floating-pad[data-state="compact"] {
+  transform: translateX(-50%) scale(0.7);
+  opacity: 0.9;
+}
+
+.floating-pad[data-state="hidden"] {
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(-50%) scale(0.6);
 }
 
 .pad-row {
   display: flex;
-  gap: 8px;
+  gap: 12px;
 }
 
 .pad-btn {
-  width: 120px;
-  height: 120px;
-  font-size: 2rem;
-  background: #1c2f49;
+  width: 100px;
+  height: 100px;
+  font-size: 2.2rem;
   border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #3a5fae, #1b2f4f);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.45);
 }
 
-.dialog {
+.pad-toggle {
   position: fixed;
-  inset: 0;
+  bottom: calc(env(safe-area-inset-bottom, 16px) + 16px);
+  right: calc(env(safe-area-inset-right, 16px) + 16px);
+  z-index: 11;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.32);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+  touch-action: none;
+}
+
+.pad-toggle.dragging {
+  cursor: grabbing;
+}
+
+#ability-buttons {
+  bottom: calc(env(safe-area-inset-bottom, 16px) + 16px);
+  left: calc(env(safe-area-inset-left, 16px) + 16px);
   display: flex;
-  justify-content: center;
-  align-items: center;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 10;
-  padding: 16px;
+  gap: 12px;
+  z-index: 9;
+}
+
+.ability-btn {
+  padding: 12px 18px;
+  border-radius: 16px;
+  font-size: 1rem;
+  background: rgba(40, 78, 142, 0.85);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.38);
 }
 
 .overlay-panel {
-  position: absolute;
-  inset: 72px 0 0;
+  position: fixed;
+  inset: 0;
   display: flex;
-  justify-content: center;
   align-items: center;
-  padding: 16px;
-  z-index: 5;
-  pointer-events: none;
+  justify-content: center;
+  padding: 24px;
+  z-index: 12;
+  pointer-events: auto;
 }
 
 .overlay-panel.hidden {
   display: none;
 }
 
-.overlay-panel .panel {
-  max-width: 100%;
-  pointer-events: auto;
+.panel {
+  width: min(92vw, 520px);
+  background: rgba(20, 32, 44, 0.92);
+  border-radius: 24px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 24px 42px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(10px);
+}
+
+.symbol {
+  font-weight: bold;
+  padding: 0 4px;
+  border-radius: 6px;
+  background: #2f6fed;
+}
+
+.symbol.enemy {
+  background: #d0006f;
+}
+
+.dialog {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 20;
+  padding: 24px;
+}
+
+.dialog.hidden {
+  display: none;
 }
 
 ol {
   padding-left: 20px;
 }
 
-@media (max-width: 680px) {
-  .game-title {
-    font-size: 1.1rem;
+.tutorial {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 25;
+}
+
+.tutorial.hidden {
+  display: none;
+}
+
+.tutorial-body {
+  width: min(90vw, 420px);
+  background: rgba(15, 24, 34, 0.95);
+  border-radius: 22px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+}
+
+@media (max-width: 720px) {
+  .pad-btn {
+    width: clamp(72px, 22vw, 110px);
+    height: clamp(72px, 22vw, 110px);
+  }
+  .floating-pad {
+    padding: 12px 16px;
+  }
+  .status-strip {
+    font-size: 0.78rem;
   }
   button {
     font-size: 0.95rem;
   }
-  .pad-btn {
-    width: 28vw;
-    height: 28vw;
-  }
 }
 
-@media (max-height: 720px) {
-  #virtual-pad {
-    margin-bottom: 12px;
+@media (max-height: 640px) {
+  .floating-pad {
+    bottom: calc(env(safe-area-inset-bottom, 12px) + 84px);
+  }
+  #ability-buttons {
+    bottom: calc(env(safe-area-inset-bottom, 12px) + 12px);
   }
 }


### PR DESCRIPTION
## Summary
- redesign the HTML layout into a full-screen canvas with overlay HUD, floating D-Pad, ability buttons, and tutorial messaging
- restyle the UI to keep the maze canvas maximized while providing fixed overlay controls adaptable to safe areas
- overhaul input, maze generation, items, player abilities, and enemy AI to support dash/smoke, swipe+D-Pad toggles, and richer maze structures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd204791a88322bfc137621dc27812