### PR TITLE
Implement roguelike dungeon crawler

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,124 +2,86 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no" />
-  <title>迷路アクション 私と敵</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>私と敵のローグ</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="app">
-    <canvas id="game-canvas" width="480" height="640" aria-label="迷路ゲーム"></canvas>
-    <div id="touch-layer" aria-hidden="true"></div>
-
-    <header class="top-bar overlay-block">
-      <h1 class="game-title">迷路アクション 私と敵</h1>
-      <div class="top-controls">
-        <button id="toggle-sound" aria-pressed="false">🔊 音ON</button>
-        <button id="open-settings">⚙️ 設定</button>
-        <button id="open-ranking">🏆 ランキング</button>
-      </div>
+  <div id="game-wrapper">
+    <header id="status-bar">
+      <div class="status-item">階: <span id="ui-floor">1F</span></div>
+      <div class="status-item">HP: <span id="ui-hp">20 / 20</span></div>
+      <div class="status-item">Lv/Exp: <span id="ui-level">1</span> / <span id="ui-exp">0</span></div>
+      <div class="status-item">満腹: <span id="ui-hunger">100%</span></div>
+      <div class="status-item">攻/防: <span id="ui-atk">1</span> / <span id="ui-def">0</span></div>
+      <div class="status-item">所持: <span id="ui-inventory">0 / 20</span></div>
     </header>
-
-    <section id="game-screen" class="overlay-block" aria-live="polite">
-      <div class="hud">
-        <div>レベル: <span id="hud-level">1</span></div>
-        <div>スコア: <span id="hud-score">0</span></div>
-        <div class="status-strip">
-          <span id="status-attack" class="status">攻撃: <span class="value">-</span></span>
-          <span id="status-invincible" class="status">無敵: <span class="value">-</span></span>
-          <span id="status-trap" class="status">罠効果: <span class="value">-</span></span>
-          <span id="status-field" class="status">環境: <span class="value">-</span></span>
-          <span id="status-dash" class="status">ダッシュ: <span class="value">Ready</span></span>
-          <span id="status-smoke" class="status">スモーク: <span class="value">0</span></span>
+    <canvas id="game-canvas" aria-label="ローグライクゲーム" role="img"></canvas>
+    <div id="message-log" aria-live="polite"></div>
+    <div id="dpad" class="dpad" data-size="full">
+      <div class="dpad-inner">
+        <button class="pad-btn" data-action="up" aria-label="上">▲</button>
+        <div class="pad-row">
+          <button class="pad-btn" data-action="left" aria-label="左">◀</button>
+          <button class="pad-btn" data-action="wait" aria-label="待機">•</button>
+          <button class="pad-btn" data-action="right" aria-label="右">▶</button>
         </div>
-        <button id="pause-button">⏸ ポーズ</button>
+        <button class="pad-btn" data-action="down" aria-label="下">▼</button>
       </div>
-      <div id="loading-indicator" class="canvas-overlay">生成中…</div>
-      <div id="pause-overlay" class="canvas-overlay hidden">ポーズ中</div>
-    </section>
-
-    <div id="ability-buttons" class="overlay-block">
-      <button id="dash-button" class="ability-btn" aria-label="ダッシュ">⚡ ダッシュ</button>
-      <button id="smoke-button" class="ability-btn" aria-label="スモーク">💨 スモーク</button>
+      <button id="pad-menu" class="pad-menu" aria-label="メニュー">≡</button>
     </div>
+    <button id="pad-toggle" class="pad-toggle" data-visibility="full" aria-label="Dパッド切替">🕹</button>
+  </div>
 
-    <div id="virtual-pad" class="floating-pad" data-state="full" aria-hidden="false">
-      <div class="pad-row">
-        <button data-dir="up" class="pad-btn" aria-label="上">▲</button>
-      </div>
-      <div class="pad-row">
-        <button data-dir="left" class="pad-btn" aria-label="左">◀</button>
-        <button data-dir="down" class="pad-btn" aria-label="下">▼</button>
-        <button data-dir="right" class="pad-btn" aria-label="右">▶</button>
-      </div>
-    </div>
-
-    <button id="pad-toggle" class="pad-toggle" aria-label="Dパッド切替" data-state="full">🕹</button>
-
-    <div id="title-screen" class="overlay-panel" aria-live="polite">
-      <div class="panel">
-        <h2>タイトル</h2>
-        <p>プレイヤー <span class="symbol">私</span> を操作して、<span class="symbol enemy">敵</span> を避けながらゴールを目指そう。</p>
-        <button id="start-button" class="primary">▶ はじめる</button>
-        <button id="show-howto">❔ 操作説明</button>
-        <div id="howto" class="hidden">
-          <p>PC: 矢印キー / WASD</p>
-          <p>スマホ: 画面下のDパッド、またはスワイプ</p>
-          <p>ダッシュ: ⚡ボタン / Space</p>
-          <p>スモーク: 💨ボタン / Eキー</p>
-          <p>一時停止: Pキー / ⏸ボタン</p>
-          <p>デバッグ: G=グリッド V=フォグ L=次レベル</p>
-        </div>
-      </div>
-    </div>
-
-    <section id="result-screen" class="overlay-panel hidden" aria-live="polite">
-      <div class="panel">
-        <h2>リザルト</h2>
-        <p>スコア: <span id="result-score">0</span></p>
-        <p>到達レベル: <span id="result-level">1</span></p>
-        <p>クリアタイム: <span id="result-time">0.0</span>s</p>
-        <form id="result-form">
-          <label>イニシャル (3文字)
-            <input id="initial-input" maxlength="3" pattern="[A-Za-zぁ-んァ-ヶ一-龥0-9]{1,3}" required />
-          </label>
-          <button type="submit" class="primary">保存</button>
-        </form>
-        <button id="retry-button">▶ もう一度</button>
-        <button id="back-title">◀ タイトルへ</button>
-      </div>
-    </section>
-
-    <section id="ranking-panel" class="dialog hidden" role="dialog" aria-modal="true">
-      <div class="panel">
-        <h2>ランキング</h2>
-        <ol id="ranking-list"></ol>
-        <button id="reset-ranking">初期化</button>
-        <button id="close-ranking" class="secondary">閉じる</button>
-      </div>
-    </section>
-
-    <section id="settings-panel" class="dialog hidden" role="dialog" aria-modal="true">
-      <div class="panel">
-        <h2>設定</h2>
-        <label>視界半径: <input id="sight-range" type="range" min="3" max="10" value="5" /></label>
-        <label>Dパッドサイズ: <input id="pad-size" type="range" min="80" max="200" value="140" /></label>
-        <label>スワイプ感度: <input id="swipe-sensitivity" type="range" min="10" max="80" value="30" /></label>
-        <label>震動: <input id="vibration-toggle" type="checkbox" checked /></label>
-        <label>画面揺れ: <input id="screenshake-toggle" type="checkbox" checked /></label>
-        <label>フォグ表示: <input id="fog-toggle" type="checkbox" checked /></label>
-        <button id="close-settings" class="secondary">閉じる</button>
-      </div>
-    </section>
-
-    <div id="tutorial-pop" class="tutorial hidden" role="status">
-      <div class="tutorial-body">
-        <h3>チュートリアル</h3>
-        <p>Dパッドは画面に重ねて表示されています。右下の🕹ボタンから縮小・非表示を切り替えできます。</p>
-        <button id="tutorial-close" class="primary">了解！</button>
+  <div id="menu-overlay" class="overlay hidden" role="dialog" aria-modal="true">
+    <div class="panel">
+      <h2>所持品</h2>
+      <ul id="inventory-list"></ul>
+      <div class="panel-buttons">
+        <button id="close-menu" class="secondary">閉じる</button>
       </div>
     </div>
   </div>
+
+  <div id="result-overlay" class="overlay hidden" role="dialog" aria-modal="true">
+    <div class="panel">
+      <h2>リザルト</h2>
+      <p>到達階: <span id="result-floor">1F</span></p>
+      <p>撃破数: <span id="result-kills">0</span></p>
+      <p>スコア: <span id="result-score">0</span></p>
+      <form id="result-form">
+        <label>名前(3文字まで)
+          <input id="result-name" maxlength="3" pattern="[A-Za-z0-9ぁ-んァ-ヶ一-龥]{1,3}" required />
+        </label>
+        <button type="submit" class="primary">ランキング登録</button>
+      </form>
+      <button id="retry-button" class="primary">再挑戦</button>
+      <button id="ranking-button">ランキングを見る</button>
+    </div>
+  </div>
+
+  <div id="ranking-overlay" class="overlay hidden" role="dialog" aria-modal="true">
+    <div class="panel">
+      <h2>ランキング</h2>
+      <ol id="ranking-list"></ol>
+      <div class="panel-buttons">
+        <button id="reset-ranking" class="danger">リセット</button>
+        <button id="close-ranking" class="secondary">閉じる</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="tutorial" class="overlay" role="dialog" aria-modal="true">
+    <div class="panel">
+      <h2>遊び方</h2>
+      <p>画面下のDパッド、スワイプ、またはキーボード(矢印/WASD/スペース)で行動します。</p>
+      <p>1行動ごとに敵も行動します。階段で降りてより深い階層を目指しましょう。</p>
+      <button id="tutorial-close" class="primary">開始</button>
+    </div>
+  </div>
+
+  <div id="toast" class="toast" aria-live="assertive"></div>
+
   <script src="main.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,342 +1,271 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", "Hiragino Sans", system-ui, sans-serif;
+  --pad-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  --panel-bg: rgba(18, 22, 32, 0.92);
+  --accent: #66d9ef;
+}
+
 * {
   box-sizing: border-box;
 }
 
-html,
 body {
   margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  font-family: "M PLUS 1p", "Noto Sans JP", sans-serif;
-  background: #0b141d;
-  color: #f5f5f5;
-}
-
-body {
+  background: #05070d;
+  color: #f0f4ff;
+  height: 100dvh;
   overflow: hidden;
 }
 
-.hidden {
-  display: none !important;
-}
-
-#app {
-  position: relative;
+#game-wrapper {
   width: 100vw;
-  height: 100vh;
-  background: #050a10;
+  height: 100dvh;
+  position: relative;
 }
 
 #game-canvas {
-  position: fixed;
-  inset: 0;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   display: block;
-  background: #050a10;
+  background: #02060e;
   pointer-events: none;
 }
 
-#touch-layer {
+#status-bar {
   position: fixed;
-  inset: 0;
-  width: 100vw;
-  height: 100vh;
-  touch-action: none;
-  pointer-events: auto;
-  background: transparent;
-  z-index: 2;
-}
-
-.overlay-block {
-  position: fixed;
-  z-index: 5;
-  pointer-events: auto;
-}
-
-.top-bar {
-  top: calc(env(safe-area-inset-top, 12px));
+  top: env(safe-area-inset-top, 0px);
   left: 50%;
   transform: translateX(-50%);
-  width: min(92vw, 620px);
+  width: min(960px, 98vw);
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: 10px 16px;
-  border-radius: 16px;
-  background: rgba(22, 33, 44, 0.85);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(6px);
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  z-index: 1500;
+  pointer-events: none;
 }
 
-.game-title {
-  font-size: clamp(1.1rem, 2.2vw, 1.6rem);
-  margin: 0;
+.status-item {
+  font-size: clamp(0.65rem, 1.1vw, 0.95rem);
+  white-space: nowrap;
 }
 
-button {
-  font-size: 1rem;
-  padding: 10px 16px;
-  border-radius: 12px;
-  border: none;
-  background: #284e8e;
-  color: #fff;
-  cursor: pointer;
-  transition: transform 0.1s ease, background 0.2s;
+#message-log {
+  position: fixed;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 220px);
+  transform: translateX(-50%);
+  width: min(720px, 92vw);
+  max-height: 20vh;
+  overflow: hidden;
+  font-size: 0.9rem;
+  text-shadow: 0 1px 2px black;
+  z-index: 1400;
+  pointer-events: none;
 }
 
-button:active {
-  transform: scale(0.97);
+#message-log p {
+  margin: 0.1rem 0;
 }
 
-button:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-button.secondary {
-  background: #3a3f47;
-}
-
-button.primary {
-  background: #2f6fed;
-}
-
-button:focus {
-  outline: 2px solid #f9c74f;
-  outline-offset: 2px;
-}
-
-#game-screen {
-  top: calc(env(safe-area-inset-top, 12px) + 76px);
+.dpad {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 16px));
   left: 50%;
   transform: translateX(-50%);
-  width: min(92vw, 620px);
-}
-
-.hud {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 10px 14px;
-  border-radius: 16px;
-  background: rgba(15, 24, 34, 0.82);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.32);
-}
-
-.status-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  font-size: 0.85rem;
-}
-
-.status {
-  padding: 4px 8px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.canvas-overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 2rem;
-  font-weight: bold;
-  color: #f5f5f5;
-  background: rgba(5, 10, 16, 0.65);
-  text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(3px);
-  z-index: 6;
-}
-
-#pause-overlay {
-  font-size: 1.6rem;
-}
-
-.floating-pad {
-  position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 16px) + 110px);
-  left: 50%;
-  transform: translateX(-50%);
-  display: grid;
-  gap: 6px;
-  justify-items: center;
-  padding: 16px 20px;
-  border-radius: 28px;
-  background: rgba(0, 0, 0, 0.28);
+  z-index: 2000;
+  background: rgba(15, 24, 40, 0.85);
+  border-radius: 18px;
+  padding: 1.2rem;
+  box-shadow: var(--pad-shadow);
   backdrop-filter: blur(8px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
-  z-index: 10;
-  transition: transform 0.2s ease, opacity 0.2s;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  touch-action: none;
 }
 
-.floating-pad[data-state="compact"] {
-  transform: translateX(-50%) scale(0.7);
-  opacity: 0.9;
+.dpad[data-size="compact"] .dpad-inner {
+  transform: scale(0.7);
 }
 
-.floating-pad[data-state="hidden"] {
-  pointer-events: none;
-  opacity: 0;
-  transform: translateX(-50%) scale(0.6);
+.dpad[data-size="hidden"] {
+  display: none;
+}
+
+.dpad-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .pad-row {
   display: flex;
-  gap: 12px;
+  gap: 0.5rem;
 }
 
-.pad-btn {
-  width: 100px;
-  height: 100px;
-  font-size: 2.2rem;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #3a5fae, #1b2f4f);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.45);
+.pad-btn,
+.pad-menu {
+  width: 64px;
+  height: 64px;
+  font-size: 1.6rem;
+  border-radius: 16px;
+  border: none;
+  background: rgba(36, 58, 86, 0.95);
+  color: #f8fbff;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+  touch-action: manipulation;
+}
+
+.pad-btn:active,
+.pad-menu:active {
+  transform: scale(0.96);
+  background: rgba(102, 217, 239, 0.9);
+  color: #031622;
+}
+
+.pad-menu {
+  font-size: 1.4rem;
 }
 
 .pad-toggle {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 16px) + 16px);
-  right: calc(env(safe-area-inset-right, 16px) + 16px);
-  z-index: 11;
-  padding: 12px 14px;
-  border-radius: 16px;
-  background: rgba(0, 0, 0, 0.32);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(6px);
-  touch-action: none;
+  bottom: calc(env(safe-area-inset-bottom, 16px) + 180px);
+  right: min(4vw, 32px);
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(36, 58, 86, 0.8);
+  color: #f0f4ff;
+  font-size: 1.4rem;
+  box-shadow: var(--pad-shadow);
+  pointer-events: auto;
+  z-index: 2001;
 }
 
-.pad-toggle.dragging {
-  cursor: grabbing;
-}
-
-#ability-buttons {
-  bottom: calc(env(safe-area-inset-bottom, 16px) + 16px);
-  left: calc(env(safe-area-inset-left, 16px) + 16px);
-  display: flex;
-  gap: 12px;
-  z-index: 9;
-}
-
-.ability-btn {
-  padding: 12px 18px;
-  border-radius: 16px;
-  font-size: 1rem;
-  background: rgba(40, 78, 142, 0.85);
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.38);
-}
-
-.overlay-panel {
+.overlay {
   position: fixed;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
-  z-index: 12;
-  pointer-events: auto;
+  background: rgba(4, 6, 10, 0.75);
+  z-index: 3000;
 }
 
-.overlay-panel.hidden {
+.overlay.hidden {
   display: none;
 }
 
 .panel {
-  width: min(92vw, 520px);
-  background: rgba(20, 32, 44, 0.92);
-  border-radius: 24px;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  box-shadow: 0 24px 42px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(10px);
-}
-
-.symbol {
-  font-weight: bold;
-  padding: 0 4px;
-  border-radius: 6px;
-  background: #2f6fed;
-}
-
-.symbol.enemy {
-  background: #d0006f;
-}
-
-.dialog {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 20;
-  padding: 24px;
-}
-
-.dialog.hidden {
-  display: none;
-}
-
-ol {
-  padding-left: 20px;
-}
-
-.tutorial {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.55);
-  z-index: 25;
-}
-
-.tutorial.hidden {
-  display: none;
-}
-
-.tutorial-body {
   width: min(90vw, 420px);
-  background: rgba(15, 24, 34, 0.95);
-  border-radius: 22px;
-  padding: 24px;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: var(--panel-bg);
+  padding: 1.2rem 1.5rem;
+  border-radius: 18px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+}
+
+.panel h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.panel-buttons {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
 }
 
-@media (max-width: 720px) {
-  .pad-btn {
-    width: clamp(72px, 22vw, 110px);
-    height: clamp(72px, 22vw, 110px);
-  }
-  .floating-pad {
-    padding: 12px 16px;
-  }
-  .status-strip {
-    font-size: 0.78rem;
-  }
-  button {
-    font-size: 0.95rem;
-  }
+button.primary {
+  background: var(--accent);
+  color: #04121d;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+  font-weight: bold;
 }
 
-@media (max-height: 640px) {
-  .floating-pad {
-    bottom: calc(env(safe-area-inset-bottom, 12px) + 84px);
+button.secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+}
+
+button.danger {
+  background: #ff4d6d;
+  color: white;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 12px;
+}
+
+button {
+  font-family: inherit;
+}
+
+#inventory-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#inventory-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.4rem 0.6rem;
+  border-radius: 10px;
+  margin-bottom: 0.4rem;
+}
+
+#inventory-list li button {
+  padding: 0.3rem 0.6rem;
+  border-radius: 8px;
+  border: none;
+  background: rgba(102, 217, 239, 0.8);
+  color: #04121d;
+}
+
+.toast {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 16px) + 280px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 24, 40, 0.9);
+  padding: 0.6rem 1rem;
+  border-radius: 14px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: 1400;
+}
+
+.toast.show {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  #status-bar {
+    flex-wrap: wrap;
+    gap: 0.2rem 0.6rem;
   }
-  #ability-buttons {
-    bottom: calc(env(safe-area-inset-bottom, 12px) + 12px);
+  .pad-btn,
+  .pad-menu {
+    width: 56px;
+    height: 56px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the page markup with a full-screen canvas HUD, overlays, and fixed overlay D-pad controls that satisfy the mobile interaction constraints
- restyle the experience with dark themed full-viewport canvas, safe-area aware overlays, and draggable/toggleable D-pad UI
- implement a complete roguelike engine: dungeon generator with room/corridor rules, turn-based player/enemy logic, traps, inventory, items, scoring, and local ranking persistence

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd694711148322a0188126f33eaecd