### PR TITLE
Improve mobile dock UX and early floor balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
             <input type="range" name="padSpacing" min="8" max="20" step="1" />
           </label>
           <label><input type="checkbox" name="haptics" /> タップ時にバイブ</label>
+          <label><input type="checkbox" name="autoHide" /> Dパッド自動縮小</label>
           <label><input type="checkbox" name="reduceMotion" /> Reduce Motion</label>
           <label><input type="checkbox" name="highContrast" /> 高コントラスト</label>
           <label>文字サイズ
@@ -140,7 +141,8 @@
     </div>
   </main>
 
-  <nav id="pad-dock" data-hand="right" aria-label="操作ドック">
+  <nav id="pad-dock" data-hand="right" aria-label="操作ドック" aria-expanded="true">
+    <button id="pad-handle" type="button" aria-label="操作ドックを表示"></button>
     <div class="dock-inner">
       <div id="reach-guide" aria-hidden="true"></div>
       <div id="thumb-zone">

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@
   --pad-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
   --pad-gap: 8px;
   --btn-press-scale: 0.96;
-  --pad-h: 0px;
+  --pad-h: 168px;
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-top: env(safe-area-inset-top, 0px);
 }
@@ -32,6 +32,7 @@ body {
   height: 100dvh;
   background: #050b18;
   overflow: hidden;
+  transition: height 200ms ease;
 }
 
 body.dock-active #stage {
@@ -55,6 +56,12 @@ body.reduce-motion * {
   width: 100%;
   height: 100%;
   pointer-events: none;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 #touch-layer {
@@ -193,25 +200,76 @@ body:not(.dock-active) #pad-dock {
   bottom: 0;
   height: calc(var(--pad-h) + var(--safe-bottom));
   padding-bottom: var(--safe-bottom);
-  background: rgba(8, 12, 20, 0.85);
+  background: rgba(8, 12, 20, 0.75);
   backdrop-filter: blur(6px);
   z-index: 3000;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
   pointer-events: none;
   overflow: visible;
+  opacity: 0.65;
+  transition: height 200ms ease, opacity 200ms ease;
+}
+
+#pad-dock.is-pressed {
+  opacity: 0.9;
 }
 
 #pad-dock .dock-inner {
   position: relative;
   width: min(100%, 720px);
   min-height: var(--pad-h);
-  padding: 16px 24px;
+  padding: 16px 24px 20px;
   display: flex;
   align-items: flex-end;
   justify-content: center;
   gap: 24px;
   pointer-events: auto;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+#pad-dock[aria-expanded="false"] {
+  height: calc(48px + var(--safe-bottom));
+}
+
+#pad-dock[aria-expanded="false"] .dock-inner {
+  opacity: 0;
+  transform: translateY(18px);
+  pointer-events: none;
+}
+
+#pad-handle {
+  width: 100%;
+  height: 32px;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  cursor: pointer;
+  padding: 8px 0 0;
+  touch-action: manipulation;
+}
+
+#pad-handle::before {
+  content: "";
+  width: 66px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.35);
+  transition: background 200ms ease, transform 200ms ease;
+}
+
+#pad-dock[aria-expanded="false"] #pad-handle {
+  height: 48px;
+}
+
+#pad-dock[aria-expanded="false"] #pad-handle::before {
+  background: rgba(255, 255, 255, 0.55);
+  transform: translateY(6px);
 }
 
 #thumb-zone {
@@ -264,11 +322,11 @@ body:not(.dock-active) #pad-dock {
 
 .dpad {
   position: relative;
-  padding: 12px 18px;
-  border-radius: 24px;
+  padding: 14px 20px;
+  border-radius: 30px;
   background: rgba(17, 24, 39, 0.82);
-  backdrop-filter: blur(12px);
-  box-shadow: var(--pad-shadow);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 28px 46px rgba(0, 0, 0, 0.55);
   touch-action: none;
   display: flex;
   flex-direction: column;
@@ -299,12 +357,12 @@ body:not(.dock-active) #pad-dock {
 .action-btn,
 #radial-menu button {
   border: none;
-  border-radius: 18px;
-  background: rgba(31, 43, 68, 0.92);
-  color: var(--text);
+  border-radius: 24px;
+  background: rgba(26, 36, 56, 0.92);
+  color: rgba(237, 242, 255, 0.95);
   font-size: 1.2rem;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
-  transition: transform 140ms ease, background 140ms ease;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
+  transition: transform 140ms ease, background 140ms ease, color 140ms ease;
   touch-action: manipulation;
 }
 
@@ -312,8 +370,8 @@ body:not(.dock-active) #pad-dock {
 .action-btn:active,
 #radial-menu button:active {
   transform: scale(1);
-  background: rgba(96, 165, 250, 0.85);
-  color: #041019;
+  background: rgba(250, 204, 21, 0.9);
+  color: #111827;
 }
 
 .pad-btn,


### PR DESCRIPTION
## Summary
- redesign the mobile dock with an auto-hiding handle, hand/size persistence, and opacity feedback
- enhance player rendering and minimap markers for clearer visibility
- rebalance the first floors with gentler enemy behaviour, guaranteed starter loot, and reduced early traps/hunger drain

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cde11d3e8483229e17cfd96eadc770